### PR TITLE
python2.6 compatibility for stinger_flask

### DIFF
--- a/flask/stinger_flask.py
+++ b/flask/stinger_flask.py
@@ -229,7 +229,7 @@ class Health(Resource):
 
 def stingerRPC(payload):
     try:
-        urlstr = 'http://{}:{}/jsonrpc'.format(STINGER_HOST,STINGER_RPC_PORT)
+        urlstr = 'http://{0}:{1}/jsonrpc'.format(STINGER_HOST,STINGER_RPC_PORT)
         r = requests.post(urlstr, data=json.dumps(payload))
     except:
         print(traceback.format_exc())


### PR DESCRIPTION
python2.7 added support for omitting positional arguments for format strings; python 2.6 still requires it